### PR TITLE
add CAN bootloader support

### DIFF
--- a/MCU/F415/openocd-unlock.cfg
+++ b/MCU/F415/openocd-unlock.cfg
@@ -85,8 +85,11 @@ show_register $USD_FAP
 show_register $EPP0
 show_register $EPP2
 
-echo "erase 2 bootloader sectors and first fw sector"
-flash erase_sector 0 0 4
+if { ![info exists ERASE_SECTORS] } {
+    set ERASE_SECTORS 4
+}
+echo "erase sectors 0 to $ERASE_SECTORS"
+flash erase_sector 0 0 $ERASE_SECTORS
 
 echo "Load bootloader"
 flash write_bank 0 $BOOTLOADER

--- a/MCU/F415/openocd-unlock.cfg
+++ b/MCU/F415/openocd-unlock.cfg
@@ -85,11 +85,11 @@ show_register $USD_FAP
 show_register $EPP0
 show_register $EPP2
 
-if { ![info exists ERASE_SECTORS] } {
-    set ERASE_SECTORS 4
+if { ![info exists ERASE_LAST_SECTOR] } {
+    set ERASE_LAST_SECTOR 4
 }
-echo "erase sectors 0 to $ERASE_SECTORS"
-flash erase_sector 0 0 $ERASE_SECTORS
+echo "erase sectors 0 to $ERASE_LAST_SECTOR"
+flash erase_sector 0 0 $ERASE_LAST_SECTOR
 
 echo "Load bootloader"
 flash write_bank 0 $BOOTLOADER

--- a/MCU/G431/openocd-unlock.cfg
+++ b/MCU/G431/openocd-unlock.cfg
@@ -90,8 +90,11 @@ show_register $FLASH_WPB
 
 halt
 
-echo "erase 2 bootloader sectors and first fw sector"
-flash erase_sector 0 0 2
+if { ![info exists ERASE_SECTORS] } {
+    set ERASE_SECTORS 2
+}
+echo "erase sectors 0 to $ERASE_SECTORS"
+flash erase_sector 0 0 $ERASE_SECTORS
 wait_till_clear $FLASH_SR 0x10000
 
 echo "Load bootloader"

--- a/MCU/G431/openocd-unlock.cfg
+++ b/MCU/G431/openocd-unlock.cfg
@@ -90,11 +90,11 @@ show_register $FLASH_WPB
 
 halt
 
-if { ![info exists ERASE_SECTORS] } {
-    set ERASE_SECTORS 2
+if { ![info exists ERASE_LAST_SECTOR] } {
+    set ERASE_LAST_SECTOR 2
 }
-echo "erase sectors 0 to $ERASE_SECTORS"
-flash erase_sector 0 0 $ERASE_SECTORS
+echo "erase sectors 0 to $ERASE_LAST_SECTOR"
+flash erase_sector 0 0 $ERASE_LAST_SECTOR
 wait_till_clear $FLASH_SR 0x10000
 
 echo "Load bootloader"

--- a/MCU/L431/openocd-unlock.cfg
+++ b/MCU/L431/openocd-unlock.cfg
@@ -90,8 +90,11 @@ show_register $FLASH_WPB
 
 halt
 
-echo "erase 2 bootloader sectors and first fw sector"
-flash erase_sector 0 0 2
+if { ![info exists ERASE_SECTORS] } {
+    set ERASE_SECTORS 2
+}
+echo "erase sectors 0 to $ERASE_SECTORS"
+flash erase_sector 0 0 $ERASE_SECTORS
 wait_till_clear $FLASH_SR 0x10000
 
 echo "Load bootloader"

--- a/MCU/L431/openocd-unlock.cfg
+++ b/MCU/L431/openocd-unlock.cfg
@@ -90,11 +90,11 @@ show_register $FLASH_WPB
 
 halt
 
-if { ![info exists ERASE_SECTORS] } {
-    set ERASE_SECTORS 2
+if { ![info exists ERASE_LAST_SECTOR] } {
+    set ERASE_LAST_SECTOR 2
 }
-echo "erase sectors 0 to $ERASE_SECTORS"
-flash erase_sector 0 0 $ERASE_SECTORS
+echo "erase sectors 0 to $ERASE_LAST_SECTOR"
+flash erase_sector 0 0 $ERASE_LAST_SECTOR
 wait_till_clear $FLASH_SR 0x10000
 
 echo "Load bootloader"

--- a/esc_unlocker.py
+++ b/esc_unlocker.py
@@ -6,6 +6,8 @@ UI for unlocking ESC MCUs for AM32 project
 PROBE_LIST = ["ST Link", "JLink", "CMSIS-DAP"]
 MCU_LIST = ["F031", "F051", "G071", "G071_64K", "G431", "L431", "E230", "F415", "F421"]
 PIN_LIST = ["PA0","PA2","PA6","PB4","PA15"]
+CAN_MCUS = ["F415", "G431", "L431"]
+CAN_ERASE_SECTORS = {"F415": 15, "G431": 8, "L431": 8}
 
 import tkinter as tk
 from tkinter import ttk, scrolledtext, filedialog
@@ -159,13 +161,16 @@ def run_openocd():
     config_file = get_resource_path(config_file)
     custom_bootloader = bootloader_var.get()
 
+    use_can = can_var.get() and mcu_base in CAN_MCUS
+    can_tag = "_CAN" if use_can else ""
+
     if custom_bootloader:
         bootloader = custom_bootloader
     else:
-        bootloader = os.path.join("bootloaders", f"AM32_{mcu_base}_BOOTLOADER_{pin}{k_tag}_V17.bin")
+        bootloader = os.path.join("bootloaders", f"AM32_{mcu_base}_BOOTLOADER_{pin}{can_tag}{k_tag}_V17.bin")
         bootloader = get_resource_path(bootloader)
 
-    log_message("Starting MCU %s PIN %s op %s" % (mcu_type, pin, op))
+    log_message("Starting MCU %s PIN %s op %s CAN %s" % (mcu_type, pin, op, use_can))
 
     using_tempfile = False
 
@@ -194,10 +199,13 @@ def run_openocd():
                 startupinfo = None
 
             openocd = get_openocd()
-            process = subprocess.Popen([openocd,
-                                        '-c', 'set BOOTLOADER "%s"' % bootloader,
-                                        '--file', probe_file,
-                                        '--file', config_file],
+            ocd_args = [openocd,
+                        '-c', 'set BOOTLOADER "%s"' % bootloader]
+            if use_can and mcu_base in CAN_ERASE_SECTORS:
+                ocd_args += ['-c', 'set ERASE_SECTORS %d' % CAN_ERASE_SECTORS[mcu_base]]
+            ocd_args += ['--file', probe_file,
+                         '--file', config_file]
+            process = subprocess.Popen(ocd_args,
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE,
                                         startupinfo=startupinfo)
@@ -260,13 +268,14 @@ root.grid_columnconfigure(0, weight=1)
 root.grid_columnconfigure(1, weight=1)
 root.grid_columnconfigure(2, weight=1)
 root.grid_columnconfigure(3, weight=1)
+root.grid_columnconfigure(4, weight=1)
 
 # Probe selection
 probe_var = tk.StringVar()
 probe_label = ttk.Label(root, text="Select Probe:")
-probe_label.grid(row=0, column=2, padx=10, pady=10)
+probe_label.grid(row=0, column=3, padx=10, pady=10)
 probe_dropdown = ttk.OptionMenu(root, probe_var, PROBE_LIST[0], *PROBE_LIST)
-probe_dropdown.grid(row=0, column=3, padx=10, pady=10)
+probe_dropdown.grid(row=0, column=4, padx=10, pady=10)
 
 # MCU type selection
 mcu_var = tk.StringVar()
@@ -282,12 +291,28 @@ pin_label.grid(row=1, column=0, padx=10, pady=10)
 pin_dropdown = ttk.OptionMenu(root, pin_var, PIN_LIST[0], *PIN_LIST)
 pin_dropdown.grid(row=1, column=1, padx=10, pady=10)
 
+# CAN bootloader checkbox
+can_var = tk.BooleanVar()
+can_check = ttk.Checkbutton(root, text="CAN", variable=can_var)
+can_check.grid(row=1, column=2, padx=10, pady=10)
+can_check.state(['disabled'])
+
+def on_mcu_change(*args):
+    mcu = mcu_var.get().split('_')[0]
+    if mcu in CAN_MCUS:
+        can_check.state(['!disabled'])
+    else:
+        can_var.set(False)
+        can_check.state(['disabled'])
+
+mcu_var.trace_add('write', on_mcu_change)
+
 # locking mode
 mode_var = tk.StringVar()
 mode_label = ttk.Label(root, text="Select Mode:")
-mode_label.grid(row=1, column=2, padx=10, pady=10)
+mode_label.grid(row=1, column=3, padx=10, pady=10)
 mode_dropdown = ttk.OptionMenu(root, mode_var, "Unlock", "Unlock", "Lock")
-mode_dropdown.grid(row=1, column=3, padx=10, pady=10)
+mode_dropdown.grid(row=1, column=4, padx=10, pady=10)
 
 # Start and Stop buttons
 start_button = ttk.Button(root, text="Start", command=start_openocd)
@@ -296,7 +321,7 @@ stop_button = ttk.Button(root, text="Stop", command=stop_openocd)
 stop_button.grid(row=2, column=2, padx=10, pady=10)
 
 stop_button = ttk.Button(root, text="Quit", command=quit)
-stop_button.grid(row=2, column=3, padx=10, pady=10)
+stop_button.grid(row=2, column=4, padx=10, pady=10)
 
 # Status LED
 canvas = tk.Canvas(root, width=20, height=20)
@@ -313,9 +338,9 @@ bootloader_var = tk.StringVar()
 bootloader_label = ttk.Label(root, text="Custom Bootloader:")
 bootloader_label.grid(row=5, column=0, padx=10, pady=10)
 bootloader_entry = ttk.Entry(root, textvariable=bootloader_var, width=40)
-bootloader_entry.grid(row=5, column=1, columnspan=2, padx=10, pady=10)
+bootloader_entry.grid(row=5, column=1, columnspan=3, padx=10, pady=10)
 bootloader_button = ttk.Button(root, text="Browse...", command=select_bootloader_file)
-bootloader_button.grid(row=5, column=3, padx=10, pady=10)
+bootloader_button.grid(row=5, column=4, padx=10, pady=10)
 
 bootloader_label = ttk.Label(root, text="Custom Bootloader:")
 bootloader_label.grid(row=5, column=0, padx=10, pady=10)
@@ -328,11 +353,11 @@ For the stable bootloaders please download from
 and use the Custom Bootloader option
 ''')
 warn.config(state=tk.DISABLED)
-warn.grid(row=6, column=0, columnspan=4, padx=10, pady=10)
+warn.grid(row=6, column=0, columnspan=5, padx=10, pady=10)
 
 
 output_text = scrolledtext.ScrolledText(root, wrap=tk.WORD, width=50, height=10)
-output_text.grid(row=7, column=0, columnspan=4, padx=10, pady=10, sticky="nsew")
+output_text.grid(row=7, column=0, columnspan=5, padx=10, pady=10, sticky="nsew")
 
 if not have_audio:
     # surface why audio is off instead of failing silently

--- a/esc_unlocker.py
+++ b/esc_unlocker.py
@@ -7,7 +7,9 @@ PROBE_LIST = ["ST Link", "JLink", "CMSIS-DAP"]
 MCU_LIST = ["F031", "F051", "G071", "G071_64K", "G431", "L431", "E230", "F415", "F421"]
 PIN_LIST = ["PA0","PA2","PA6","PB4","PA15"]
 CAN_MCUS = ["F415", "G431", "L431"]
-CAN_ERASE_SECTORS = {"F415": 15, "G431": 8, "L431": 8}
+# index of the last flash sector to erase for the larger CAN bootloaders
+# (passed to "flash erase_sector 0 0 <last>", which is inclusive)
+CAN_ERASE_LAST_SECTOR = {"F415": 15, "G431": 8, "L431": 8}
 
 import tkinter as tk
 from tkinter import ttk, scrolledtext, filedialog
@@ -201,8 +203,8 @@ def run_openocd():
             openocd = get_openocd()
             ocd_args = [openocd,
                         '-c', 'set BOOTLOADER "%s"' % bootloader]
-            if use_can and mcu_base in CAN_ERASE_SECTORS:
-                ocd_args += ['-c', 'set ERASE_SECTORS %d' % CAN_ERASE_SECTORS[mcu_base]]
+            if use_can and mcu_base in CAN_ERASE_LAST_SECTOR:
+                ocd_args += ['-c', 'set ERASE_LAST_SECTOR %d' % CAN_ERASE_LAST_SECTOR[mcu_base]]
             ocd_args += ['--file', probe_file,
                          '--file', config_file]
             process = subprocess.Popen(ocd_args,
@@ -306,6 +308,7 @@ def on_mcu_change(*args):
         can_check.state(['disabled'])
 
 mcu_var.trace_add('write', on_mcu_change)
+on_mcu_change()  # sync checkbox state to the initial MCU selection
 
 # locking mode
 mode_var = tk.StringVar()


### PR DESCRIPTION
Add a CAN checkbox to the GUI, enabled only for MCUs with CAN bootloader variants (F415, G431, L431). When selected, the tool uses the _CAN bootloader files and passes a larger ERASE_SECTORS value to OpenOCD to accommodate the ~13-15KB CAN bootloaders.