### PR TITLE
fix cross-platform run/audio bugs in the packaged app

### DIFF
--- a/esc_unlocker.py
+++ b/esc_unlocker.py
@@ -429,6 +429,11 @@ running = False
 
 # play queued tones on a daemon thread, off the Tk main loop
 if have_audio:
+    try:
+        dev = sd.query_devices(kind='output')
+        log_message("audio: sounddevice %s, output device '%s'" % (sd.__version__, dev['name']))
+    except Exception as e:
+        log_message("audio: no usable output device: %s" % e)
     threading.Thread(target=audio_worker, daemon=True).start()
 
 def process_gui_queue():
@@ -445,6 +450,50 @@ def process_gui_queue():
     root.after(50, process_gui_queue)
 
 root.after(50, process_gui_queue)
+
+def apply_cli_args():
+    '''optional command-line control, handy for automated/headless testing'''
+    import argparse
+    parser = argparse.ArgumentParser(description="AM32 ESC Unlocker")
+    parser.add_argument('--mcu', choices=MCU_LIST, help='MCU type')
+    parser.add_argument('--port', '--pin', dest='pin', choices=PIN_LIST, help='signal pin')
+    parser.add_argument('--probe', choices=PROBE_LIST, help='debug probe')
+    parser.add_argument('--mode', choices=['Unlock', 'Lock'], help='operation')
+    parser.add_argument('--bootloader', help='custom bootloader file')
+    parser.add_argument('--can', action='store_true', help='use the CAN bootloader variant')
+    parser.add_argument('--start', action='store_true', help='press Start automatically')
+    parser.add_argument('--test-audio', action='store_true',
+                        help='play test tones and log the outcome (audio diagnostics)')
+    parser.add_argument('--exit-after', type=float, default=0,
+                        help='quit automatically after N seconds (testing)')
+    # parse_known_args so a macOS .app launch arg (-psn_...) doesn't abort
+    args, _ = parser.parse_known_args()
+
+    if args.mcu:
+        mcu_var.set(args.mcu)        # fires on_mcu_change -> enables CAN if applicable
+    if args.pin:
+        pin_var.set(args.pin)
+    if args.probe:
+        probe_var.set(args.probe)
+    if args.mode:
+        mode_var.set(args.mode)
+    if args.bootloader:
+        bootloader_var.set(args.bootloader)
+    if args.can:
+        can_var.set(True)
+    if args.test_audio:
+        def _audio_test():
+            log_message("audio test: starting (have_audio=%s)" % have_audio)
+            play_tone(880, 0.3)
+            play_tone(660, 0.3)
+            log_message("audio test: done (no exception from sd.play)")
+        threading.Thread(target=_audio_test, daemon=True).start()
+    if args.start:
+        root.after(500, start_openocd)
+    if args.exit_after > 0:
+        root.after(int(args.exit_after * 1000), quit)
+
+apply_cli_args()
 
 # Start the GUI event loop
 root.mainloop()

--- a/esc_unlocker.py
+++ b/esc_unlocker.py
@@ -152,14 +152,16 @@ def get_openocd():
         openocd = "tools/linux/openocd/bin/openocd"
     return get_resource_path(openocd)
 
-def run_openocd():
+def run_openocd(params):
     '''
-    run openocd as a child, looping until running is False or success
+    run openocd as a child, looping until running is False or success.
+    params holds the GUI selections, read on the main thread by the caller -
+    the worker must never touch Tk (macOS Aqua wedges the event loop if it does)
     '''
     global running, current_process
     running = True
-    mcu_type = mcu_var.get()
-    probe_type = probe_var.get()
+    mcu_type = params['mcu_type']
+    probe_type = params['probe_type']
     if probe_type == "ST Link":
         probe_type = "stlink"
     elif probe_type == "JLink":
@@ -167,8 +169,9 @@ def run_openocd():
     elif probe_type == "CMSIS-DAP":
         probe_type = "cmsis-dap"
 
-    pin = pin_var.get()
-    if mode_var.get() == "Lock":
+    pin = params['pin']
+    mode = params['mode']
+    if mode == "Lock":
         op = "lock"
     else:
         op = "unlock"
@@ -183,9 +186,9 @@ def run_openocd():
     probe_file = get_resource_path(f"probes/{probe_type}.cfg")
 
     config_file = get_resource_path(config_file)
-    custom_bootloader = bootloader_var.get()
+    custom_bootloader = params['custom_bootloader']
 
-    use_can = can_var.get() and mcu_base in CAN_MCUS
+    use_can = params['can'] and mcu_base in CAN_MCUS
     can_tag = "_CAN" if use_can else ""
 
     if custom_bootloader:
@@ -259,7 +262,7 @@ def run_openocd():
             if retcode is not None:
                 if retcode == 0:
                     log_message("Success")
-                    print("%s successful." % mode_var.get())
+                    print("%s successful." % mode)
                     play_success()
                     gui_call(lambda: update_status_led("green"))
                     running = False
@@ -276,7 +279,17 @@ def run_openocd():
 def start_openocd():
     if not running:
         output_text.delete(1.0, tk.END)
-        thd = threading.Thread(target=run_openocd)
+        # read all GUI state here on the main thread and hand it to the worker;
+        # the worker must not call any Tk method (unsafe, hangs macOS)
+        params = {
+            'mcu_type': mcu_var.get(),
+            'probe_type': probe_var.get(),
+            'pin': pin_var.get(),
+            'mode': mode_var.get(),
+            'custom_bootloader': bootloader_var.get(),
+            'can': can_var.get(),
+        }
+        thd = threading.Thread(target=run_openocd, args=(params,), daemon=True)
         thd.start()
 
 def terminate_process():
@@ -298,7 +311,9 @@ def quit():
     global running
     running = False
     terminate_process()
-    sys.exit(0)
+    # destroy() reliably ends mainloop; sys.exit() can be swallowed by Tk, and
+    # the worker is a daemon thread so the process exits cleanly
+    root.destroy()
 
 def update_status_led(color):
     canvas.itemconfig(led, fill=color)

--- a/esc_unlocker.py
+++ b/esc_unlocker.py
@@ -40,7 +40,21 @@ import tempfile
 is_windows = platform.system() == "Windows"
 is_macos = platform.system() == "Darwin"
 
-pending_tones = []
+# In a --windowed/--noconsole PyInstaller build sys.stdout/stderr are None, so
+# any print() raises - which would kill the OpenOCD worker thread mid-run.
+# Redirect to devnull so the existing print() calls are always safe.
+if sys.stdout is None:
+    sys.stdout = open(os.devnull, "w")
+if sys.stderr is None:
+    sys.stderr = open(os.devnull, "w")
+
+# tones are played on a dedicated thread so blocking PortAudio calls never
+# stall the Tk main loop (doing this on the main thread caused severe UI lag
+# on macOS)
+audio_queue = queue.Queue()
+
+# the currently running openocd child, so Stop can terminate it
+current_process = None
 
 # Tkinter is not thread-safe: widgets may only be touched from the thread
 # running mainloop(). The OpenOCD worker thread pushes callables onto this
@@ -74,22 +88,30 @@ def play_tone(frequency, duration=0.1, volume=0.2):
         sd.play(audio, sample_rate)
         sd.wait()
     except Exception as e:
-        print(e)
-        pass
+        log_message("audio error: %s" % e)
 
+
+def queue_tone(frequency, duration=0.1):
+    '''enqueue a tone for the audio thread (bounded so it can't back up)'''
+    if have_audio and audio_queue.qsize() < 4:
+        audio_queue.put((frequency, duration))
+
+def audio_worker():
+    '''play queued tones off the GUI thread'''
+    while True:
+        frequency, duration = audio_queue.get()
+        play_tone(frequency, duration)
 
 def play_searching():
-    print("Searching")
-    pending_tones.append((300, 0.1))
+    queue_tone(300, 0.1)
 
 def play_found():
-    print("Found")
-    pending_tones.append((880, 0.1))
+    queue_tone(880, 0.1)
 
 def play_success():
-    pending_tones.append((600, 0.1))
-    pending_tones.append((800, 0.1))
-    pending_tones.append((1000, 0.1))
+    queue_tone(600, 0.1)
+    queue_tone(800, 0.1)
+    queue_tone(1000, 0.1)
 
 
 def log_message(msg):
@@ -134,7 +156,7 @@ def run_openocd():
     '''
     run openocd as a child, looping until running is False or success
     '''
-    global running
+    global running, current_process
     running = True
     mcu_type = mcu_var.get()
     probe_type = probe_var.get()
@@ -211,6 +233,8 @@ def run_openocd():
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE,
                                         startupinfo=startupinfo)
+            # expose to stop_openocd() so Stop can terminate a blocked attempt
+            current_process = process
 
             output = process.stdout.read().decode()
             if output:
@@ -220,6 +244,9 @@ def run_openocd():
             if outerr:
                 append_output(outerr)
                 log_message(outerr)
+            if not running:
+                # Stop was pressed (process terminated); don't beep or relaunch
+                break
             if outerr.find("Cortex-M") != -1:
                 # found the MCU
                 play_found()
@@ -238,7 +265,11 @@ def run_openocd():
                     running = False
         except Exception as e:
             print(f"Error running OpenOCD: {e}")
+        # brief pause so a fast-failing attempt doesn't busy-loop relaunching
+        if running:
+            time.sleep(0.3)
 
+    current_process = None
     if using_tempfile:
         os.unlink(tfile)
 
@@ -248,14 +279,25 @@ def start_openocd():
         thd = threading.Thread(target=run_openocd)
         thd.start()
 
+def terminate_process():
+    '''kill the in-flight openocd child, if any, to unblock the worker thread'''
+    p = current_process
+    if p is not None:
+        try:
+            p.terminate()
+        except Exception:
+            pass
+
 def stop_openocd():
     global running
     running = False
+    terminate_process()
     log_message("stopping")
 
 def quit():
     global running
     running = False
+    terminate_process()
     sys.exit(0)
 
 def update_status_led(color):
@@ -370,12 +412,9 @@ if not have_audio:
 
 running = False
 
-def play_tones():
-    '''callback to play tones'''
-    while len(pending_tones) > 0:
-        tone,duration = pending_tones.pop()
-        play_tone(tone, duration)
-    root.after(10, play_tones)
+# play queued tones on a daemon thread, off the Tk main loop
+if have_audio:
+    threading.Thread(target=audio_worker, daemon=True).start()
 
 def process_gui_queue():
     '''run GUI actions queued by the worker thread (main thread only)'''
@@ -390,7 +429,6 @@ def process_gui_queue():
         pass
     root.after(50, process_gui_queue)
 
-root.after(10, play_tones)
 root.after(50, process_gui_queue)
 
 # Start the GUI event loop


### PR DESCRIPTION
Three issues surfaced by CI-built releases:

1. Windows: nothing happened on Start and there was no sound. In a --windowed/--noconsole build sys.stdout/stderr are None, so the print() calls in run_openocd() (outside the try) raised and killed the worker thread before openocd ever launched. Redirect None stdout/stderr to devnull so all print() calls are safe.

2. macOS: severe UI lag on Start. Tones were played on the Tk main thread (sd.play()/sd.wait() block, with high PortAudio per-call latency on macOS), freezing the GUI. Play tones on a dedicated daemon thread fed by a bounded queue; the GUI/worker only enqueue.

3. Stop did nothing: it set running=False but the worker stayed blocked in process.stdout.read() and openocd was never killed. Track the child as current_process and terminate() it on Stop/Quit, and break out of the retry loop once stopped. Also add a short pause between attempts so a fast-failing probe can't busy-loop relaunching openocd.